### PR TITLE
Add support for creating disks using the machine driver

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+docker run --rm -it -v "$PWD":/usr/src/nutanix-docker-machine -w /usr/src/nutanix-docker-machine/machine golang:1.14 go build -v -o /usr/src/nutanix-docker-machine/docker-machine-driver-nutanix 
+sudo mv docker-machine-driver-nutanix /usr/local/bin

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-docker run --rm -it -v "$PWD":/usr/src/nutanix-docker-machine -w /usr/src/nutanix-docker-machine/machine golang:1.14 go build -v -o /usr/src/nutanix-docker-machine/docker-machine-driver-nutanix 
-sudo mv docker-machine-driver-nutanix /usr/local/bin


### PR DESCRIPTION
Use `--nutanix-storage-container` to specify a storage container by UUID and `--nutanix-disk-size` to specify the disk size in GiB. If either one is not set the other parameter is ignored.