### PR TITLE
Fix/update go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,61 @@
 .idea/
 build/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+.vscode/*.code-snippets
+
+# Ignore code-workspaces
+*.code-workspace
+
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,26 @@
-module nutanix
+module github.com/nutanix/docker-machine
 
-go 1.14
+go 1.18
 
 replace github.com/docker/docker => github.com/docker/engine v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
-	github.com/docker/docker v1.13.1 // indirect
 	github.com/docker/machine v0.16.2
 	github.com/nutanix-cloud-native/prism-go-client v0.2.0
 	github.com/sirupsen/logrus v1.8.1
 	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/PaesslerAG/gval v1.0.0 // indirect
+	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
+	github.com/docker/docker v1.13.1 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/machine/driver/driver.go
+++ b/machine/driver/driver.go
@@ -10,12 +10,11 @@ import (
 	"strings"
 	"time"
 
-	"nutanix/utils"
-
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/mcnflag"
 	"github.com/docker/machine/libmachine/ssh"
 	"github.com/docker/machine/libmachine/state"
+	"github.com/nutanix/docker-machine/utils"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 

--- a/machine/main.go
+++ b/machine/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"github.com/docker/machine/libmachine/drivers/plugin"
-	nutanix "nutanix/machine/driver"
+	"github.com/nutanix/docker-machine/machine/driver"
 )
 
 func main() {
-	plugin.RegisterDriver(nutanix.NewDriver("", ""))
+	plugin.RegisterDriver(driver.NewDriver("", ""))
 }


### PR DESCRIPTION
Update Go framework to 1.18
rename Go project
add gitignore template for macOS and vscode