### PR TITLE
add GPU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This repository contains the Rancher Node Driver for Nutanix. Nutanix Node drive
 - Project support
 - Serial Port support
 - Boot type selection : Legacy or UEFI 
+- GPU support
 
 
 ## Installation
@@ -83,6 +84,7 @@ If you want to use Nutanix Node Driver, you need add it in order to start using 
 | `nutanix-vm-image`           | The name of the Disk Image template we use for the newly created VM (must support cloud-init) | yes      |         |
 | `nutanix-vm-image-size`      | The new size of the Image we use as a template (in GiB)                                       | no       |         |
 | `nutanix-vm-categories`      | The name of the categories who will be applied to the newly created VM                        | no       |         |
+| `nutanix-vm-gpu`             | The name of GPU to attach to the newly created VM                                             | no       |         |
 | `nutanix-project`            | The name of the project where deploy the VM (default if empty)                                | no       | default |
 | `nutanix-disk-size`          | The size of the additional disk to add to the VM (in GiB)                                     | no       |         |
 | `nutanix-storage-container`  | The storage container UUID of the additional disk to add to the VM                            | no       |         |

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/docker/docker => github.com/docker/engine v17.12.0-ce-rc1.0.2
 require (
 	github.com/docker/machine v0.16.2
 	github.com/google/uuid v1.6.0
-	github.com/nutanix-cloud-native/prism-go-client v0.5.2
+	github.com/nutanix-cloud-native/prism-go-client v0.5.3
 	github.com/sirupsen/logrus v1.9.3
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/nutanix-cloud-native/prism-go-client v0.5.2 h1:qhFJeC3CRrWM8BTaNvxnjShVNH5E99z5MPU3a2BO14A=
 github.com/nutanix-cloud-native/prism-go-client v0.5.2/go.mod h1:N/O9fz5fimjb30RxlPbKbGs/Z2lqMgDqrb6CrsZvQrA=
+github.com/nutanix-cloud-native/prism-go-client v0.5.3 h1:kcwbrWQOkQHiK20LcL2HyRYMlOWXLgqR93JD7D9ZgAs=
+github.com/nutanix-cloud-native/prism-go-client v0.5.3/go.mod h1:N/O9fz5fimjb30RxlPbKbGs/Z2lqMgDqrb6CrsZvQrA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/machine/driver/utils.go
+++ b/machine/driver/utils.go
@@ -1,8 +1,13 @@
 package driver
 
 import (
+	"context"
+	"fmt"
 	"regexp"
 
+	log "github.com/sirupsen/logrus"
+
+	v3 "github.com/nutanix-cloud-native/prism-go-client/v3"
 	"gopkg.in/yaml.v3"
 )
 
@@ -85,3 +90,78 @@ func buildScalarNodes(key string) []*yaml.Node {
 // 	}
 // 	return n1, n2
 // }
+
+// GetGPUList retrieves a list of GPUs from the Nutanix Prism Element based on the provided GPU names and PE UUID.
+// It returns a slice of VMGpu pointers or an error if any issues occur during the retrieval
+func GetGPUList(ctx context.Context, conn *v3.Client, gpus []string, peUUID string) ([]*v3.VMGpu, error) {
+	resultGPUs := make([]*v3.VMGpu, 0)
+	for _, gpu := range gpus {
+		foundGPU, err := GetGPU(ctx, conn, peUUID, gpu)
+		if err != nil {
+			return nil, err
+		}
+		resultGPUs = append(resultGPUs, foundGPU)
+	}
+	return resultGPUs, nil
+}
+
+// GetGPU retrieves a specific GPU from the Nutanix Prism Element based on the provided GPU name and PE UUID.
+// It returns a VMGpu pointer or an error if the GPU is not found or if any issues occur during the retrieval.
+func GetGPU(ctx context.Context, conn *v3.Client, peUUID, gpu string) (*v3.VMGpu, error) {
+	if gpu == "" {
+		return nil, fmt.Errorf("gpu name must be passed in order to retrieve the GPU")
+	}
+
+	log.Infof("Searching GPU %s in Prism Element with UUID %s", gpu, peUUID)
+	allGPUs, err := GetGPUsForPE(ctx, conn, peUUID)
+	if err != nil {
+		return nil, err
+	}
+	if len(allGPUs) == 0 {
+		return nil, fmt.Errorf("no available GPUs found in Prism Element cluster with UUID %s", peUUID)
+	}
+	for _, peGPU := range allGPUs {
+		if peGPU.Status != "UNUSED" {
+			continue
+		}
+		if peGPU.Name == gpu {
+			log.Infof("GPU %s found with ID %d in Prism Element", peGPU.Name, *peGPU.DeviceID)
+			return &v3.VMGpu{
+				DeviceID: peGPU.DeviceID,
+				Mode:     &peGPU.Mode,
+				Vendor:   &peGPU.Vendor,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("no available GPU found in Prism Element that matches required GPU name: %s", gpu)
+
+}
+
+// GetGPUsForPE retrieves all GPUs associated with a specific Prism Element (PE) UUID.
+// It returns a slice of GPU pointers or an error if any issues occur during the retrieval.
+func GetGPUsForPE(ctx context.Context, conn *v3.Client, peUUID string) ([]*v3.GPU, error) {
+	gpus := make([]*v3.GPU, 0)
+	hosts, err := conn.V3.ListAllHost(ctx)
+	if err != nil {
+		return gpus, err
+	}
+
+	for _, host := range hosts.Entities {
+		if host == nil ||
+			host.Status == nil ||
+			host.Status.ClusterReference == nil ||
+			host.Status.Resources == nil ||
+			len(host.Status.Resources.GPUList) == 0 ||
+			host.Status.ClusterReference.UUID != peUUID {
+			continue
+		}
+
+		for _, peGpu := range host.Status.Resources.GPUList {
+			if peGpu == nil {
+				continue
+			}
+			gpus = append(gpus, peGpu)
+		}
+	}
+	return gpus, nil
+}


### PR DESCRIPTION
This pull request adds support for attaching GPU devices to Nutanix VMs during creation. It introduces new configuration options and logic to select and assign available GPUs, as well as error handling improvements during VM creation failures.

**GPU support for VM creation:**

* Added a `GPUs` field to the `NutanixDriver` struct to store the list of GPU devices to attach to a VM.
* Added a new CLI flag `--nutanix-vm-gpu` for specifying GPU devices, and updated the driver configuration to parse this flag. [[1]](diffhunk://#diff-4073e4a8dacf49454d32330f80f715b86160a861a21fe753e689dbc04383b2ceR667-R670) [[2]](diffhunk://#diff-4073e4a8dacf49454d32330f80f715b86160a861a21fe753e689dbc04383b2ceR872-R873)
* Integrated GPU selection logic into the VM creation process: retrieves available GPUs, matches them by name, and attaches them to the VM if specified.
* Implemented utility functions in `utils.go` (`GetGPUList`, `GetGPU`, `GetGPUsForPE`) to fetch and filter available GPUs from the Nutanix cluster, ensuring only unused GPUs are selected. [[1]](diffhunk://#diff-8c8de3dd89b8b8caf9b2696b84114cd82d61519523035498e19eddfb3a48af6bR4-R10) [[2]](diffhunk://#diff-8c8de3dd89b8b8caf9b2696b84114cd82d61519523035498e19eddfb3a48af6bR93-R161)

**Error handling improvements:**

* On VM creation failure, the driver now attempts to clean up by deleting the partially created VM, logging any errors encountered during the cleanup.