### PR TITLE
fix goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Create release on GitHub
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --rm-dist
+          version: "~> v2"
+          args: release --clean
           workdir: machine
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/machine/.goreleaser.yaml
+++ b/machine/.goreleaser.yaml
@@ -1,4 +1,5 @@
-# .goreleaser.yml
+version: 2
+
 project_name: docker-machine-driver-nutanix
 
 builds:
@@ -11,7 +12,7 @@ builds:
 
 archives:
   - name_template: "{{ .ProjectName }}"
-    format: binary
+    formats: binary
 
 checksum:
   name_template: "{{ .ProjectName }}_v{{ .Version }}_checksums.txt"


### PR DESCRIPTION
This pull request updates the release workflow and configuration to support GoReleaser v2, ensuring compatibility with the latest release process and configuration standards. The changes include updating the GitHub Actions workflow and modifying the GoReleaser configuration file to use the new version format and options.

Release workflow updates:

* Updated the `goreleaser/goreleaser-action` step in `.github/workflows/release.yml` to use GoReleaser v2 and changed the release arguments from `--rm-dist` to `--clean` for compatibility with v2.

GoReleaser configuration updates:

* Set the `version` field to `2` in `machine/.goreleaser.yaml` to indicate the configuration is for GoReleaser v2.
* Changed the `archives` section in `machine/.goreleaser.yaml` to use `formats` instead of `format`, aligning with the v2 configuration syntax.