### PR TITLE
Add support for Prism Central Service Accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repository contains the Rancher Node Driver for Nutanix. Nutanix Node drive
 - Serial Port support
 - Boot type selection : Legacy or UEFI 
 - GPU support
+- Prism Central Service Accounts support
 
 
 ## Installation
@@ -104,8 +105,10 @@ Starting `v3.3.0` the Rancher Node driver implements Nutanix Project support. Th
   - Cluster View Access
   - Image View Only
 
+## Service Accounts support
 
-
+Starting version 3.8.0, the Rancher Node Driver support Prism Central Service Accounts. 
+To use a Service Account, you need to provide `X-ntnx-api-key` as the user name and the corresponding API Key as the password.
 
 ## Development
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/docker/docker => github.com/docker/engine v17.12.0-ce-rc1.0.2
 require (
 	github.com/docker/machine v0.16.2
 	github.com/google/uuid v1.6.0
-	github.com/nutanix-cloud-native/prism-go-client v0.5.4
+	github.com/nutanix-cloud-native/prism-go-client v0.5.5
 	github.com/sirupsen/logrus v1.9.3
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/nutanix-cloud-native/prism-go-client v0.5.4 h1:MUZ3dSDRhBQWAYn1HQ0JRb/O0N13GILwiMHMlMT92Zo=
-github.com/nutanix-cloud-native/prism-go-client v0.5.4/go.mod h1:N/O9fz5fimjb30RxlPbKbGs/Z2lqMgDqrb6CrsZvQrA=
+github.com/nutanix-cloud-native/prism-go-client v0.5.5 h1:xonicVCBo/JASp0R2ivlksLDAnnxSAQqsISXBqoNeYs=
+github.com/nutanix-cloud-native/prism-go-client v0.5.5/go.mod h1:N/O9fz5fimjb30RxlPbKbGs/Z2lqMgDqrb6CrsZvQrA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
This pull request adds support for Prism Central Service Accounts to the Rancher Node Driver for Nutanix and updates documentation to reflect this new feature. Additionally, it updates the dependency on the `prism-go-client` library to the latest version.

**Service Account Support:**

* Added support for Prism Central Service Accounts, allowing users to authenticate using `X-ntnx-api-key` as the username and the API Key as the password. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R111)
* Updated the `README.md` to document Service Account support and provide usage instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R111)

**Dependency Update:**

* Upgraded `github.com/nutanix-cloud-native/prism-go-client` from version `v0.5.4` to `v0.5.5` in `go.mod` to ensure compatibility with new features.