### PR TITLE
Update download and UI URLs for version 3.8.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ If you want to use Nutanix Node Driver, you need add it in order to start using 
 2. Click *Add Node Driver*.
 3. Complete the Add Node Driver form. Then click Create.
 
-    - *Download URL*: `https://github.com/nutanix/docker-machine/releases/download/v3.7.0/docker-machine-driver-nutanix`  
-    - *Custom UI URL*: `https://nutanix.github.io/rancher-ui-driver/v3.7.0/component.js`
+    - *Download URL*: `https://github.com/nutanix/docker-machine/releases/download/v3.8.0/docker-machine-driver-nutanix`  
+    - *Custom UI URL*: `https://nutanix.github.io/rancher-ui-driver/v3.8.0/component.js`
     - *Checksum*: `2f70c4bdccd3c5e68bd8c32aadb5b525275a3cda5799f29736f37bdd168caa94`  
     - *Whitelist Domains*: `nutanix.github.io`  
       


### PR DESCRIPTION
This pull request updates the documentation to reference the latest version of the Nutanix Node Driver. The most important change is updating the URLs in the instructions to point to version 3.8.0 instead of 3.7.0.

Documentation updates:

* Updated the `Download URL` and `Custom UI URL` in the `README.md` to reference Nutanix Node Driver version 3.8.0.